### PR TITLE
WSL(ubuntu20.04) でビルドすると失敗する問題を修正

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -465,6 +465,7 @@ definitions:
       cursor: "ew0K4oCdcHJldmlvdXNQcm9jZXNzVHlwZeKAnToxMjM1NjcsDQoicmVxdWVzdERhdGV0aW1lIjoiMjAxOC0wNi0wNVQwNDo1MDo0MFoiLA0KInByZXZpb3VzSUQiOjEyMzQ1LA0KImxhc3RFdmFsdWF0ZWRLZXkiOnsia2V5IjoxMjM0NTZ9DQp9DQoNCiA="
       hasNext: false
 
+  # TODO: 定義がどこからも使われていない警告がでるため、解消する方法を調査すること
   ActualShippingData:
     type: "object"
     description: "出荷実績データの出力ファイルの情報"
@@ -1084,6 +1085,7 @@ definitions:
       secretAccessKey: "xtzwg/8m5G9yXb7jh9g2EF9/4t6izdBakbQJyD9x"
       sessionToken: "abcd1234"
       expiration: "2019-08-15T0412:42:13Z"
+  # TODO: 定義がどこからも使われていない警告がでるため、解消する方法を調査すること
   InactiveTrackingIdData:
     type: "object"
     description: "無効追跡IDリスト"

--- a/api.yml
+++ b/api.yml
@@ -149,7 +149,8 @@ info:
     これは本サービスの問題ではなく、クラウドプラットフォームの一時的な問題です。
     少し時間をおいてからリトライしてください。複数回同じステータスになる場合はお問い合わせください。
 
-host: api.atlas-things.io/v1/
+host: api.atlas-things.io
+basePath: /v1
 schemes:
   - https
 tags:
@@ -585,7 +586,8 @@ definitions:
           格納パス  
           階層化した複数のItem.trackingIdを「/」で連結し、先頭および末尾に「/」を追加したものです。
       itemCount:
-        type: "int64"
+        type: integer
+        format: int64
         description: "アイテム数"
       movedDateTime:
         type: "string"
@@ -801,7 +803,8 @@ definitions:
           クラウドにて補完するために追跡IDに「#」を指定した場合、格納パスの末尾の階層にも「#」を指定してください。  
           なお、「#」の指定は格納パスの末尾の階層にのみ可能です。
       itemCount:
-        type: "int64"
+        type: integer
+        format: int64
         description: "アイテム数"
       movedDateTime:
         type: "string"
@@ -868,7 +871,8 @@ definitions:
               自動無効化対象パス   
               自動無効化対象のItem.trackingIdを「/」で連結し、先頭および末尾に「/」を追加したものです。
           elapsedDays:
-            type: "int64"
+            type: integer
+            format: int64
             description: "自動無効化経過日数"
         required:
           - isAutoInactivated

--- a/package.json
+++ b/package.json
@@ -10,9 +10,10 @@
   "author": "OGIS-RI",
   "license": "Ask https://xxxxx.com/",
   "dependencies": {
+    "cheerio": "1.0.0-rc.6",
+    "coffeescript": "^2.5.1",
     "rimraf": "^3.0.2",
     "spectacle-docs": "^1.1.0",
-    "swagger-tools": "^0.10.4",
-    "cheerio": "1.0.0-rc.6"
+    "swagger-tools": "^0.10.4"
   }
 }


### PR DESCRIPTION
netlify のビルドイメージを ubuntu 20.04 に更新する必要がある。
その検証でWSLでビルドしたら失敗したので、その問題を解決する。